### PR TITLE
[COOK-2919] Status option not available 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,7 @@ template "keepalived.conf" do
 end
 
 service "keepalived" do
-  supports :restart => true, :status => true
+  supports :restart => true
   action [:enable, :start]
   subscribes :restart, "template[keepalived.conf]"
 end


### PR DESCRIPTION
In the current Ubuntu release it appears 'status' is not an option for the keepalived init script. 

http://tickets.opscode.com/browse/COOK-2919
