### PR TITLE
Migration of Static_Ipaddresses to Custom Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ This file is used to list changes made in each version of the keepalived cookboo
   - Added property `cookbook`, defaulted to: `keepalived`
   - Added property `source`, defaulted to `global_defs.conf.erb`
   - Added property `extra_options`
+- Migrated static_ipaddress from HWRP to a Custom Resource
+  - Removed property `config_name`
+  - Removed property `content`, this is now build up from the supplied properties
+  - Removed property `path`
+  - Removed property `exists`
+  - Added property `conf_directory`, defaulted to: `/etc/keepalived/conf.d`
+  - Added property `config_file`, defaulted to: `::File.join(conf_directory, 'static_ipaddress.conf')`
+  - Added property `cookbook`, defaulted to: `keepalived`
+  - Added property `source`, defaulted to `static_ipaddress.conf.erb`
 
 ## 3.1.1 (2018-01-10)
 

--- a/README.md
+++ b/README.md
@@ -68,27 +68,6 @@ Property | Type   | Default
 content  | String | #to_conf
 path     | String | dynamically computed
 
-### Static IP Addresses
-
-The `keepalived_static_ipaddress` resource is a singleton resource, which can be used to manage configuration within the `static_ipaddress` section of keepalived.conf
-
-Example:
-
-```ruby
-keepalived_static_ipaddress 'static_ipaddress' do
-  addresses [
-    '192.168.1.2/24 dev eth0 scope global',
-    '192.168.1.3/24 dev eth0 scope global'
-  ]
-end
-```
-
-Supported properties:
-
-Property  | Type  | Default
---------- | ----- | -------
-addresses | Array | nil
-
 ### Static Routes
 
 The `keepalived_static_routes` resource is a singleton resource, which can be used to manage configuration within the `static_routes` section of keepalived.conf.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,3 +16,10 @@ the `cookbook` and `source` properites on resources allow you to override the te
 - Added property `config_file`, defaulted to: `::File.join(conf_directory, 'global_defs.conf')`
 - Added property `cookbook`, defaulted to: `keepalived`
 - Added property `source`, defaulted to `global_defs.conf.erb`
+
+### keepalived_static_ipaddress
+
+- Added property `conf_directory`, defaulted to: `/etc/keepalived/conf.d`
+- Added property `config_file`, defaulted to: `::File.join(conf_directory, 'static_ipaddress.conf')`
+- Added property `cookbook`, defaulted to: `keepalived`
+- Added property `source`, defaulted to `static_ipaddress.conf.erb`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,9 @@ the `cookbook` and `source` properites on resources allow you to override the te
 
 ### keepalived_static_ipaddress
 
+- Removed property `config_name`, path now will be the full name
+- Removed property `content`, this is now build up from the supplied properties
+- Removed property `exists`
 - Added property `conf_directory`, defaulted to: `/etc/keepalived/conf.d`
 - Added property `config_file`, defaulted to: `::File.join(conf_directory, 'static_ipaddress.conf')`
 - Added property `cookbook`, defaulted to: `keepalived`

--- a/documentation/keepalived_static_ipaddress.md
+++ b/documentation/keepalived_static_ipaddress.md
@@ -1,0 +1,35 @@
+[back to resource list](https://github.com/sous-chefs/keepalived#resources)
+
+---
+
+# keepalived_static_ipaddress
+
+The `keepalived_static_ipaddress` resource can be used to manage configuration within the `static_ipaddress` section of keepalived.conf.
+
+More information available at <https://www.keepalived.org/manpage.html>
+
+## Actions
+
+`:create`
+`:delete`
+
+## Properties
+
+| Name        | Type        |  Default | Description | Allowed Values |
+------------- | ----------- | -------- | ----------- | -------------- |
+| `addresses` | `Array`       | `nil` | (Required) A list of IP Address declarations | |
+| `conf_directory` | `String` | `/etc/keepalived/conf.d` | directory for the config file to reside in | |
+| `config_file` | `String` | `::File.join(conf_directory, 'static_ipaddress.conf')` | full path to the config file | |
+| `cookbook` | `String` | `keepalived` | Which cookbook to look in for the template | |
+| `source` | `String` | `static_ipaddress.conf.erb` | Name of the template to render | |
+
+## Examples
+
+```ruby
+keepalived_static_ipaddress 'static_ipaddress' do
+  addresses [
+    '192.168.1.98/24 dev eth0 scope global',
+    '192.168.1.99/24 dev eth0 scope global',
+  ]
+end
+```

--- a/libraries/keepalived.rb
+++ b/libraries/keepalived.rb
@@ -23,8 +23,6 @@ module Keepalived
   HEALTH_PATH ||= "#{ROOT_PATH}/checks.d".freeze
   RESOURCES ||= %w(
     config
-    global_defs
-    static_ipaddress
     static_routes
     vrrp_sync_group
     vrrp_script
@@ -38,39 +36,6 @@ module Keepalived
     smtp_check
     misc_check
   ).map { |r| "keepalived_#{r}".to_sym }.freeze
-
-  module GlobalDefs
-    OPTIONS ||= {
-      notification_email: { kind_of: Array },
-      notification_email_from: { kind_of: String },
-      smtp_server: { kind_of: String },
-      smtp_helo_name: { kind_of: String },
-      smtp_connect_timeout: { kind_of: Integer },
-      router_id: { kind_of: String },
-      vrrp_mcast_group4: { kind_of: String },
-      vrrp_mcast_group6: { kind_of: String },
-      vrrp_garp_master_delay: { kind_of: Integer },
-      vrrp_garp_master_repeat: { kind_of: Integer },
-      vrrp_garp_master_refresh: { kind_of: Integer },
-      vrrp_garp_master_refresh_repeat: { kind_of: Integer },
-      vrrp_version: { kind_of: Integer, equal_to: [2, 3] },
-      vrrp_iptables: { kind_of: String },
-      vrrp_check_unicast_src: { kind_of: String },
-      vrrp_strict: { kind_of: [TrueClass, FalseClass] },
-      vrrp_priority: { kind_of: Integer, equal_to: -20.upto(19).to_a },
-      checker_priority: { kind_of: Integer, equal_to: -20.upto(19).to_a },
-      vrrp_no_swap: { kind_of: [TrueClass, FalseClass] },
-      checker_no_swap: { kind_of: [TrueClass, FalseClass] },
-      snmp_socket: { kind_of: String },
-      enable_snmp_keepalived: { kind_of: [TrueClass, FalseClass] },
-      enable_snmp_checker: { kind_of: [TrueClass, FalseClass] },
-      enable_snmp_rfc: { kind_of: [TrueClass, FalseClass] },
-      enable_snmp_rfcv2: { kind_of: [TrueClass, FalseClass] },
-      enable_snmp_rfcv3: { kind_of: [TrueClass, FalseClass] },
-      enable_traps: { kind_of: [TrueClass, FalseClass] },
-      enable_script_security: { kind_of: [TrueClass, FalseClass] },
-    }.freeze
-  end
 
   module Notify
     OPTIONS ||= {

--- a/libraries/resources.rb
+++ b/libraries/resources.rb
@@ -47,25 +47,25 @@ class ChefKeepalived
       end
     end
 
-    class StaticIpAddress < Config
-      resource_name :keepalived_static_ipaddress
-      identity_attr :config_name
+    # class StaticIpAddress < Config
+    #   resource_name :keepalived_static_ipaddress
+    #   identity_attr :config_name
 
-      property :addresses, kind_of: Array, required: true, desired_state: false
+    #   property :addresses, kind_of: Array, required: true, desired_state: false
 
-      private
+    #   private
 
-      def config_name
-        :static_ipaddress
-      end
+    #   def config_name
+    #     :static_ipaddress
+    #   end
 
-      def to_conf
-        cfg = ["#{config_name} {"]
-        cfg << addresses.join("\n\t")
-        cfg << '}'
-        cfg.join("\n\t")
-      end
-    end
+    #   def to_conf
+    #     cfg = ["#{config_name} {"]
+    #     cfg << addresses.join("\n\t")
+    #     cfg << '}'
+    #     cfg.join("\n\t")
+    #   end
+    # end
 
     class StaticRoutes < Config
       resource_name :keepalived_static_routes

--- a/libraries/resources.rb
+++ b/libraries/resources.rb
@@ -47,26 +47,6 @@ class ChefKeepalived
       end
     end
 
-    # class StaticIpAddress < Config
-    #   resource_name :keepalived_static_ipaddress
-    #   identity_attr :config_name
-
-    #   property :addresses, kind_of: Array, required: true, desired_state: false
-
-    #   private
-
-    #   def config_name
-    #     :static_ipaddress
-    #   end
-
-    #   def to_conf
-    #     cfg = ["#{config_name} {"]
-    #     cfg << addresses.join("\n\t")
-    #     cfg << '}'
-    #     cfg.join("\n\t")
-    #   end
-    # end
-
     class StaticRoutes < Config
       resource_name :keepalived_static_routes
       identity_attr :config_name

--- a/resources/static_ipaddress.rb
+++ b/resources/static_ipaddress.rb
@@ -1,0 +1,25 @@
+property :addresses,      Array, required: true
+property :conf_directory, String, default: '/etc/keepalived/conf.d'
+property :config_file,    String, default: lazy { ::File.join(conf_directory, 'static_ipaddress.conf') }
+property :cookbook,       String, default: 'keepalived'
+property :source,         String, default: 'static_ipaddress.conf.erb'
+
+action :create do
+  template new_resource.config_file do
+    source new_resource.source
+    cookbook new_resource.cookbook
+    variables(
+      addresses: new_resource.addresses
+    )
+    owner 'root'
+    group 'root'
+    mode '0640'
+    action :create
+  end
+end
+
+action :delete do
+  file new_resource.config_file do
+    action :delete
+  end
+end

--- a/spec/resources/static_ipaddress_spec.rb
+++ b/spec/resources/static_ipaddress_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+# see documentation here: https://www.keepalived.org/manpage.html
+
+static_ipaddress_config_file = '/etc/keepalived/conf.d/static_ipaddress.conf'
+
+platforms = %w(debian ubuntu centos)
+platforms.each do |platform|
+  describe "keepalived_static_ipaddress on #{platform}" do
+    step_into :keepalived_static_ipaddress
+    platform platform
+
+    context 'Create a base config correctly' do
+      recipe do
+        keepalived_static_ipaddress 'static_ipaddress' do
+          addresses [
+            'foo',
+          ]
+        end
+      end
+
+      it('should render an empty config file') do
+        is_expected.to render_file(static_ipaddress_config_file).with_content(/static_ipaddress\s+\{.*\}/m)
+      end
+
+      it 'creates the config file with the owner, group and mode' do
+        expect(chef_run).to create_template(static_ipaddress_config_file).with(
+            owner: 'root',
+            group: 'root',
+            mode: '0640'
+          )
+      end
+    end
+
+    context 'Create a config file with defined ip addresses' do
+      recipe do
+        keepalived_static_ipaddress 'static_ipaddress' do
+          addresses [
+            '192.168.1.98/24 dev eth0 scope global',
+            '192.168.1.99/24 dev eth0 scope global',
+          ]
+        end
+      end
+
+      describe 'should render config file with the ip addresses' do
+        it {
+          is_expected.to render_file(static_ipaddress_config_file)
+            .with_content(%r{192\.168\.1\.98/24 dev eth0 scope global})
+            .with_content(%r{192\.168\.1\.99/24 dev eth0 scope global})
+        }
+      end
+    end
+  end
+end

--- a/spec/unit/resources_spec.rb
+++ b/spec/unit/resources_spec.rb
@@ -12,25 +12,6 @@ describe ChefKeepalived::Resource::Config do
   end
 end
 
-describe ChefKeepalived::Resource::StaticIpAddress do
-  let(:static_ipaddress) do
-    ChefKeepalived::Resource::StaticIpAddress.new('static_ipaddress').tap do |r|
-      r.addresses [
-        '192.168.1.98/24 dev eth0 scope global',
-        '192.168.1.99/24 dev eth0 scope global',
-      ]
-    end
-  end
-
-  let(:static_ipaddress_string) do
-    "static_ipaddress {\n\t192.168.1.98/24 dev eth0 scope global\n\t192.168.1.99/24 dev eth0 scope global\n\t}"
-  end
-
-  it 'sets a proper static_ipaddress configuration' do
-    expect(static_ipaddress.content).to eq static_ipaddress_string
-  end
-end
-
 describe ChefKeepalived::Resource::StaticRoutes do
   let(:static_routes) do
     ChefKeepalived::Resource::StaticRoutes.new('static_routes').tap do |r|

--- a/templates/static_ipaddress.conf.erb
+++ b/templates/static_ipaddress.conf.erb
@@ -1,0 +1,5 @@
+static_ipaddress {
+<% @addresses.each do | address | -%>
+	<%= address %>
+<% end %>
+}


### PR DESCRIPTION
### Description

This commit migrates the keepalived_static_ipaddresses to a custom resource, it includes all documentation and full unit testing of the resource.

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
