### PR TITLE
Migration of static_routes to custom resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ This file is used to list changes made in each version of the keepalived cookboo
   - Added property `cookbook`, defaulted to: `keepalived`
   - Added property `source`, defaulted to `global_defs.conf.erb`
   - Added property `extra_options`
+- Migrated static_routes from HWRP to a Custom Resource
+  - Removed property `config_name`, path now will be the full name
+  - Removed property `content`, this is now build up from the supplied properties
+  - Removed property `exists`
+  - Added property `conf_directory`, defaulted to: `/etc/keepalived/conf.d`
+  - Added property `config_file`, defaulted to: `::File.join(conf_directory, 'static_routes.conf')`
+  - Added property `cookbook`, defaulted to: `keepalived`
+  - Added property `source`, defaulted to `static_routes.conf.erb`
 
 ## 3.1.1 (2018-01-10)
 

--- a/README.md
+++ b/README.md
@@ -89,27 +89,6 @@ Property  | Type  | Default
 --------- | ----- | -------
 addresses | Array | nil
 
-### Static Routes
-
-The `keepalived_static_routes` resource is a singleton resource, which can be used to manage configuration within the `static_routes` section of keepalived.conf.
-
-Example:
-
-```ruby
-keepalived_static_routes 'static_routes' do
-  routes [
-    '192.168.2.0/24 via 192.168.1.100 dev eth0',
-    '192.168.3.0/24 via 192.168.1.100 dev eth0'
-  ]
-end
-```
-
-Supported properties:
-
-Property | Type  | Default
--------- | ----- | -------
-routes   | Array | nil
-
 ### VRRP Sync Groups
 
 The `keepalived_vrrp_sync_group` resource can be used to configure VRRP Sync Groups (groups of resources that fail over together).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,3 +16,13 @@ the `cookbook` and `source` properites on resources allow you to override the te
 - Added property `config_file`, defaulted to: `::File.join(conf_directory, 'global_defs.conf')`
 - Added property `cookbook`, defaulted to: `keepalived`
 - Added property `source`, defaulted to `global_defs.conf.erb`
+
+### keepalived_static_routes
+
+- Removed property `config_name`, path now will be the full name
+- Removed property `content`, this is now build up from the supplied properties
+- Removed property `exists`
+- Added property `conf_directory`, defaulted to: `/etc/keepalived/conf.d`
+- Added property `config_file`, defaulted to: `::File.join(conf_directory, 'static_ipaddress.conf')`
+- Added property `cookbook`, defaulted to: `keepalived`
+- Added property `source`, defaulted to `static_ipaddress.conf.erb`

--- a/documentation/keepalived_static_routes.md
+++ b/documentation/keepalived_static_routes.md
@@ -1,0 +1,35 @@
+[back to resource list](https://github.com/sous-chefs/keepalived#resources)
+
+---
+
+# keepalived_static_routes
+
+The `keepalived_static_routes` resource can be used to manage configuration within the `static_routes` section of keepalived.conf.
+
+More information available at <https://www.keepalived.org/manpage.html>
+
+## Actions
+
+`:create`
+`:delete`
+
+## Properties
+
+| Name        | Type        |  Default | Description | Allowed Values |
+------------- | ----------- | -------- | ----------- | -------------- |
+| `addresses` | `Array`       | `nil` | (Required) A list of IP Address declarations | |
+| `conf_directory` | `String` | `/etc/keepalived/conf.d` | directory for the config file to reside in | |
+| `config_file` | `String` | `::File.join(conf_directory, 'static_routes.conf')` | full path to the config file | |
+| `cookbook` | `String` | `keepalived` | Which cookbook to look in for the template | |
+| `source` | `String` | `static_routes.conf.erb` | Name of the template to render | |
+
+## Examples
+
+```ruby
+keepalived_static_routes 'static_routes' do
+  routes [
+    '192.168.2.0/24 via 192.168.1.100 dev eth0',
+    '192.168.3.0/24 via 192.168.1.100 dev eth0',
+  ]
+end
+```

--- a/libraries/keepalived.rb
+++ b/libraries/keepalived.rb
@@ -25,7 +25,6 @@ module Keepalived
     config
     global_defs
     static_ipaddress
-    static_routes
     vrrp_sync_group
     vrrp_script
     vrrp_instance

--- a/libraries/resources.rb
+++ b/libraries/resources.rb
@@ -67,26 +67,6 @@ class ChefKeepalived
       end
     end
 
-    class StaticRoutes < Config
-      resource_name :keepalived_static_routes
-      identity_attr :config_name
-
-      property :routes, kind_of: Array, required: true, desired_state: false
-
-      private
-
-      def config_name
-        :static_routes
-      end
-
-      def to_conf
-        cfg = ["#{config_name} {"]
-        cfg << routes.join("\n\t")
-        cfg << '}'
-        cfg.join("\n\t")
-      end
-    end
-
     class VrrpSyncGroup < Config
       resource_name :keepalived_vrrp_sync_group
 

--- a/resources/static_routes.rb
+++ b/resources/static_routes.rb
@@ -1,0 +1,25 @@
+property :routes,         Array, required: true
+property :conf_directory, String, default: '/etc/keepalived/conf.d'
+property :config_file,    String, default: lazy { ::File.join(conf_directory, 'static_routes.conf') }
+property :cookbook,       String, default: 'keepalived'
+property :source,         String, default: 'static_routes.conf.erb'
+
+action :create do
+  template new_resource.config_file do
+    source new_resource.source
+    cookbook new_resource.cookbook
+    variables(
+      routes: new_resource.routes
+    )
+    owner 'root'
+    group 'root'
+    mode '0640'
+    action :create
+  end
+end
+
+action :delete do
+  file new_resource.config_file do
+    action :delete
+  end
+end

--- a/spec/resources/static_routes_spec.rb
+++ b/spec/resources/static_routes_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+# see documentation here: https://www.keepalived.org/manpage.html
+
+static_routes_config_file = '/etc/keepalived/conf.d/static_routes.conf'
+
+platforms = %w(debian ubuntu centos)
+platforms.each do |platform|
+  describe "keepalived_static_routes on #{platform}" do
+    step_into :keepalived_static_routes
+    platform platform
+
+    context 'Create a base config correctly' do
+      recipe do
+        keepalived_static_routes 'static_routes' do
+          routes [
+            'foo',
+          ]
+        end
+      end
+
+      it('should render an empty config file') do
+        is_expected.to render_file(static_routes_config_file).with_content(/static_routes\s+\{.*\}/m)
+      end
+
+      it 'creates the config file with the owner, group and mode' do
+        expect(chef_run).to create_template(static_routes_config_file).with(
+            owner: 'root',
+            group: 'root',
+            mode: '0640'
+          )
+      end
+    end
+
+    context 'Create a config file with defined routes' do
+      recipe do
+        keepalived_static_routes 'static_routes' do
+          routes [
+            '192.168.2.0/24 via 192.168.1.100 dev eth0',
+            '192.168.3.0/24 via 192.168.1.100 dev eth0',
+          ]
+        end
+      end
+
+      describe 'should render config file with the routes' do
+        it {
+          is_expected.to render_file(static_routes_config_file)
+            .with_content(%r{192\.168\.2\.0/24 via 192\.168\.1\.100 dev eth0})
+            .with_content(%r{192\.168\.3\.0/24 via 192\.168\.1\.100 dev eth0})
+        }
+      end
+    end
+  end
+end

--- a/spec/unit/resources_spec.rb
+++ b/spec/unit/resources_spec.rb
@@ -31,25 +31,6 @@ describe ChefKeepalived::Resource::StaticIpAddress do
   end
 end
 
-describe ChefKeepalived::Resource::StaticRoutes do
-  let(:static_routes) do
-    ChefKeepalived::Resource::StaticRoutes.new('static_routes').tap do |r|
-      r.routes [
-        '192.168.2.0/24 via 192.168.1.100 dev eth0',
-        '192.168.3.0/24 via 192.168.1.200 dev eth0',
-      ]
-    end
-  end
-
-  let(:static_routes_string) do
-    "static_routes {\n\t192.168.2.0/24 via 192.168.1.100 dev eth0\n\t192.168.3.0/24 via 192.168.1.200 dev eth0\n\t}"
-  end
-
-  it 'sets a proper static_routes configuration' do
-    expect(static_routes.content).to eq static_routes_string
-  end
-end
-
 describe ChefKeepalived::Resource::VrrpSyncGroup do
   let(:vrrp_sync_group) do
     ChefKeepalived::Resource::VrrpSyncGroup.new('VG_1').tap do |r|

--- a/templates/static_routes.conf.erb
+++ b/templates/static_routes.conf.erb
@@ -1,0 +1,5 @@
+static_routes {
+<% @routes.each do | route | -%>
+  <%= route %>
+<% end %>
+}


### PR DESCRIPTION
### Description

This commit migrates the keepalived_static_routes to a custom resource, it includes all documentation and full unit testing of the resource.

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
