### PR TITLE
Fixes vrrp_script to ouput a vrrp_sync block

### DIFF
--- a/templates/vrrp_script.conf.erb
+++ b/templates/vrrp_script.conf.erb
@@ -1,4 +1,4 @@
-vrrp_sync_group <%= @script_name %> {
+vrrp_script <%= @script_name %> {
   script <%= @script.to_s %>
 <% if @interval %>
   interval <%= @interval.to_s %>


### PR DESCRIPTION
### Description

It fixes the output of the `keepalived_vrrp_script` helper which is rendering a `vrrp_sync_group` block instead of a `vrrp_sync` one.