### PR TITLE
Make the authentication property optional for the keepalived_vrrp_instance resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the keepalived cookbook.
 
+## Unreleased
+
+- Make the property `authentication` of `keepalived_vrrp_instance` optional
+
 ## 5.0.0
 
 - Removed all attributes

--- a/documentation/keepalived_vrrp_instance.md
+++ b/documentation/keepalived_vrrp_instance.md
@@ -33,7 +33,7 @@ More information available at <https://www.keepalived.org/manpage.html>
 | `garp_master_refresh_repeat` | `Integer` | `nil` | number of gratuitous ARP messages to send at a time while MASTER | |
 | `priority` | `Integer` | `100` | for electing MASTER, highest priority wins | `0` up to `255` |
 | `advert_int` | `Integer` | `nil` | VRRP Advert interval in seconds | |
-| `authentication` | `Hash` | `nil` | (required) See Manpage | `:auth_type`,`:auth_pass` Note: Symbols |
+| `authentication` | `Hash` | `nil` | See Manpage | `:auth_type`,`:auth_pass` Note: Symbols |
 | `virtual_ipaddress` | `Array` | `nil` | addresses add or del on change to MASTER, to BACKUP | |
 | `virtual_ipaddress_excluded` | `Array` | `nil` | See ManPage | |
 | `virtual_routes` | `Array` | `nil` | routes add or del when changing to MASTER, to BACKUP | |

--- a/resources/vrrp_instance.rb
+++ b/resources/vrrp_instance.rb
@@ -16,14 +16,14 @@ property :garp_master_refresh,        Integer
 property :garp_master_refresh_repeat, Integer
 property :priority,                   Integer, equal_to: 0.upto(255).to_a, default: 100
 property :advert_int,                 Integer
-property :authentication,             Hash, required: true, callbacks: {
-                                                                        'has required configuration' => lambda do |spec|
-                                                                          [:auth_type, :auth_pass].all? { |c| spec.keys.map(&:to_sym).include?(c) }
-                                                                        end,
-                                                                        'has supported auth_type' => lambda do |spec|
-                                                                          (%w(PASS AH) & [spec[:auth_type], spec['auth_type']]).any?
-                                                                        end,
-                                                                      }
+property :authentication,             Hash, callbacks: {
+                                                        'has required configuration' => lambda do |spec|
+                                                          [:auth_type, :auth_pass].all? { |c| spec.keys.map(&:to_sym).include?(c) }
+                                                        end,
+                                                        'has supported auth_type' => lambda do |spec|
+                                                          (%w(PASS AH) & [spec[:auth_type], spec['auth_type']]).any?
+                                                        end,
+                                                      }
 property :virtual_ipaddress,          Array
 property :virtual_ipaddress_excluded, Array
 property :virtual_routes,             Array

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -58,6 +58,9 @@ keepalived_vrrp_script 'chk_haproxy' do
 end
 
 keepalived_vrrp_instance 'inside_network' do
+  # this intentionally has no authentication set to test that
+  # instances without authentication settings are accepted and
+  # generate correct configuration
   master true
   dont_track_primary true
   virtual_router_id 1
@@ -65,10 +68,6 @@ keepalived_vrrp_instance 'inside_network' do
   interface node['network']['default_interface']
   unicast_peer %w( 10.120.13.1 )
   track_script %w( chk_haproxy )
-  authentication(
-    auth_type: 'PASS',
-    auth_pass: 'buttz'
-  )
   virtual_ipaddress %w( 192.168.4.92 )
   sensitive true
   notifies :restart, 'service[keepalived]', :delayed
@@ -171,4 +170,9 @@ keepalived_virtual_server '192.168.1.5 80' do
   quorum 2
   real_servers http_servers
   notifies :restart, 'service[keepalived]', :delayed
+end
+
+# clean up an instance
+keepalived_vrrp_instance 'obsolete_network' do
+  action :delete
 end

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -60,11 +60,17 @@ control 'is configured' do
   describe file('/etc/keepalived/conf.d/keepalived_vrrp_instance__inside_network__.conf') do
     its(:content) { should match(/virtual_router_id 1/) }
     its(:content) { should match(/state MASTER/) }
+    its(:content) { should_not match(/authentication/) }
   end
 
   describe file('/etc/keepalived/conf.d/keepalived_vrrp_instance__outside_network__.conf') do
     its(:content) { should match(/virtual_router_id 2/) }
     its(:content) { should match(/state MASTER/) }
+    its(:content) { should match(/authentication/) }
+  end
+
+  describe file('/etc/keepalived/conf.d/keepalived_vrrp_instance__obsolete_network__.conf') do
+    it { should_not exist }
   end
 
   describe file('/etc/keepalived/conf.d/keepalived_vrrp_sync_group__VG_1__.conf') do


### PR DESCRIPTION
# Description

Since authentication is deprecated for VRRPv2 and not even defined for VRRPv3 it is not appropriate that the resource requires an authentication block. This PR makes this property
optional.

## Issues Resolved

This fixes #74.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
