### PR TITLE
Add virtual_router_id to fix test

### DIFF
--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -174,5 +174,6 @@ end
 
 # clean up an instance
 keepalived_vrrp_instance 'obsolete_network' do
+  virtual_router_id 1
   action :delete
 end


### PR DESCRIPTION
# Description

obsolete_network test was failing due to missing property, this commit adds back the missing property

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
