### PR TITLE
New: add support for latest LVS/IPVS scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the keepalived cookbook.
 
-## 5.2.0
+## Unreleased
 
 - Added support for LVS/IPVS scheduler to `keepalived_virtual_server` `lvs_sched` property:
   - `mh` "maglev hashing scheduling"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file is used to list changes made in each version of the keepalived cookbook.
 
+## 5.2.0
+
+- Added support for LVS/IPVS scheduler to `keepalived_virtual_server` `lvs_sched` property:
+  - `mh` "maglev hashing scheduling"
+  - `fo` "weighted failover scheduling"
+  - `ovf` "weighted overflow scheduling"
+  - `lblcr` "locality-based least-connection with replication scheduling"
+  - `sed` "shortest expected delay scheduling"
+  - `nq` "never queue scheduling"
+
 ## 5.1.0
 
 - Make the property `authentication` of `keepalived_vrrp_instance` optional

--- a/documentation/keepalived_virtual_server.md
+++ b/documentation/keepalived_virtual_server.md
@@ -21,7 +21,7 @@ More information available at <https://www.keepalived.org/manpage.html>
 | `real_servers` | `Array` | `nil` | Real Servers this is a virtual server for, will use include to load their files | |
 | `ip_family` | `String` | `nil` | IP family for a fwmark service | `inet`, `inet6` |
 | `delay_loop` | `Integer` | `nil` | delay timer for checker polling | |
-| `lvs_sched` | `String` | `nil` | LVS scheduler | `rr`, `wrr`, `lc`, `wlc`, `lblc`, `sh`, `dh` |
+| `lvs_sched` | `String` | `nil` | LVS scheduler | `rr`, `wrr`, `lc`, `wlc`, `lblc`, `sh`, `mh`, `dh`, `fo`, `ovf`, `lblcr`, `sed`, `nq` |
 | `ops` | `true`, `false` | `nil` | Enable One-Packet-Scheduling for UDP | |
 | `lvs_method` | `String` | `nil` | Default LVS forwarding method | `NAT`, `DR` |
 | `persistence_engine` | `String` | `nil` | LVS persistence engine name | `sip` |

--- a/resources/virtual_server.rb
+++ b/resources/virtual_server.rb
@@ -2,7 +2,7 @@ property :ip_address,               String, name_property: true
 property :real_servers,             Array, required: true
 property :ip_family,                String, equal_to: %w( inet inet6 )
 property :delay_loop,               Integer
-property :lvs_sched,                String, equal_to: %w( rr wrr lc wlc lblc sh dh )
+property :lvs_sched,                String, equal_to: %w( rr wrr lc wlc lblc sh mh dh fo ovf lblcr sed nq )
 property :ops,                      [true, false]
 property :lvs_method,               String, equal_to: %w( NAT DR TUN )
 property :persistence_engine,       String

--- a/spec/resources/virtual_server_spec.rb
+++ b/spec/resources/virtual_server_spec.rb
@@ -58,7 +58,7 @@ platforms.each do |platform|
       end
     end
 
-    context 'When given inputs for lvs_sched, ops and lvs_method' do
+    context 'When given inputs for lvs_sched = rr, ops and lvs_method = NAT' do
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -82,6 +82,52 @@ platforms.each do |platform|
       end
       it('should render a config file with the ops correctly') do
         is_expected.to render_file(file_name).with_content(/ops/)
+      end
+    end
+
+    context 'When given inputs for lvs_sched = wlc, lvs_method = DR' do
+      ip_address = '192.168.1.1 80'
+      file_name = virtual_server_file_name(ip_address)
+      real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
+      recipe do
+        keepalived_virtual_server ip_address do
+          real_servers real_servers
+          lvs_sched 'wlc'
+          lvs_method 'DR'
+        end
+      end
+
+      it('should render a config file') do
+        is_expected.to render_file(file_name).with_content(/virtual_server #{ip_address}\s+\{.*\}/m)
+      end
+      it('should render a config file with the lvs_sched correctly') do
+        is_expected.to render_file(file_name).with_content(/lvs_sched\swlc/)
+      end
+      it('should render a config file with the lvs_method correctly') do
+        is_expected.to render_file(file_name).with_content(/lvs_method\sDR/)
+      end
+    end
+
+    context 'When given inputs for lvs_sched = ovf, ops and lvs_method = DR' do
+      ip_address = '192.168.1.1 80'
+      file_name = virtual_server_file_name(ip_address)
+      real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
+      recipe do
+        keepalived_virtual_server ip_address do
+          real_servers real_servers
+          lvs_sched 'ovf'
+          lvs_method 'DR'
+        end
+      end
+
+      it('should render a config file') do
+        is_expected.to render_file(file_name).with_content(/virtual_server #{ip_address}\s+\{.*\}/m)
+      end
+      it('should render a config file with the lvs_sched correctly') do
+        is_expected.to render_file(file_name).with_content(/lvs_sched\sovf/)
+      end
+      it('should render a config file with the lvs_method correctly') do
+        is_expected.to render_file(file_name).with_content(/lvs_method\sDR/)
       end
     end
     context 'When given inputs for persistence_engine, persistence_timeout and persistence_granularity' do


### PR DESCRIPTION
Following LVS/IPVS scheduler have been added:

* mh "maglev hashing scheduling"
* fo "weighted failover scheduling"
* ovf "weighted overflow scheduling"
* lblcr "locality-based least-connection with replication scheduling"
* sed "shortest expected delay scheduling"
* nq "never queue scheduling"

[net/netfilter/ipvs/Kconfig](https://github.com/torvalds/linux/blob/master/net/netfilter/ipvs/Kconfig)

# Description

This MR adds support for latest LVS/IPVS scheduler.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ X] All tests pass. See TESTING.md for details.
- [ X] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable.
