### PR TITLE
Enable unified_mode for Chef 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the keepalived cookboo
 
 - Enable unified_mode for all resources
   - This bumps the required Chef version to at least 15.3
+- Speed up spec tests by caching Chef run
 
 ## 5.2.1 - *2021-06-01*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the keepalived cookboo
 
 ## Unreleased
 
+- Enable unified_mode for all resources
+  - This bumps the required Chef version to at least 15.3
+
 ## 5.2.1 - *2021-06-01*
 
 ## 5.2.0 - *2020-11-25*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-- Chef 13+
+- Chef 15.3+
 
 ## Recommended Background Reading
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache-2.0'
 description      'Installs and configures keepalived'
 source_url       'https://github.com/sous-chefs/keepalived'
 issues_url       'https://github.com/sous-chefs/keepalived/issues'
-chef_version     '>= 13'
+chef_version     '>= 15.3'
 version          '5.2.1'
 
 supports 'ubuntu'

--- a/resources/global_defs.rb
+++ b/resources/global_defs.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 property :notification_email,               Array
 property :notification_email_from,          String

--- a/resources/http_get.rb
+++ b/resources/http_get.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :url,                Hash, default: { path: '/', status_code: 200 }, callbacks: {
                                                                               'has only valid keys' => lambda do |spec|
                                                                                 spec.keys.all? { |s| [:path, :digest, :status_code].include?(s) }

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :package_name, String, default: 'keepalived'
 property :root_path,    String, default: '/etc/keepalived'
 property :config_path,  String, default: lazy { "#{root_path}/conf.d" }

--- a/resources/misc_check.rb
+++ b/resources/misc_check.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :misc_path,        String
 property :misc_timeout,     Integer
 property :warmup,           Integer

--- a/resources/real_server.rb
+++ b/resources/real_server.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :ipaddress,          String, required: true
 property :port,               Integer, required: true, equal_to: 1.upto(65_535)
 property :healthcheck,        String

--- a/resources/smtp_check.rb
+++ b/resources/smtp_check.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :helo_name,          String
 property :delay_before_retry, Integer
 property :connect_ip,         String

--- a/resources/ssl_get.rb
+++ b/resources/ssl_get.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :url,                Hash, default: { path: '/', status_code: 200 }, callbacks: {
                                               'has only valid keys' => lambda do |spec|
                                                 spec.keys.all? { |s| [:path, :digest, :status_code].include?(s) }

--- a/resources/static_ipaddress.rb
+++ b/resources/static_ipaddress.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :addresses,        Array, required: true
 property :config_directory, String, default: '/etc/keepalived/conf.d'
 property :config_file,      String, default: lazy { ::File.join(config_directory, 'static_ipaddress.conf') }

--- a/resources/static_routes.rb
+++ b/resources/static_routes.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :routes,           Array, required: true
 property :config_directory, String, default: '/etc/keepalived/conf.d'
 property :config_file,      String, default: lazy { ::File.join(config_directory, 'static_routes.conf') }

--- a/resources/tcp_check.rb
+++ b/resources/tcp_check.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :connect_ip,       String
 property :connect_port,     Integer, equal_to: 1.upto(65_535)
 property :connect_timeout,  Integer

--- a/resources/virtual_server.rb
+++ b/resources/virtual_server.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :ip_address,               String, name_property: true
 property :real_servers,             Array, required: true
 property :ip_family,                String, equal_to: %w( inet inet6 )

--- a/resources/virtual_server_group.rb
+++ b/resources/virtual_server_group.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :vips,             Array, default: []
 property :fwmarks,          Array, default: [], callbacks: {
                                                 'are all integers' => ->(spec) { spec.all? { |i| i.is_a?(Integer) } },

--- a/resources/vrrp_instance.rb
+++ b/resources/vrrp_instance.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :instance_name,              String, name_property: true
 
 property :virtual_router_id,          Integer, required: true, equal_to: 0.upto(255).to_a

--- a/resources/vrrp_script.rb
+++ b/resources/vrrp_script.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :script,           String, required: true
 property :interval,         Integer
 property :timeout,          Integer

--- a/resources/vrrp_sync_group.rb
+++ b/resources/vrrp_sync_group.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :notify_master,    String
 property :notify_backup,    String
 property :notify_fault,     String

--- a/spec/resources/global_defs_spec.rb
+++ b/spec/resources/global_defs_spec.rb
@@ -11,6 +11,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_global_defs 'global_defs' do
         end
@@ -21,7 +22,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(global_defs_config_file).with(
+        is_expected.to create_template(global_defs_config_file).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -30,6 +31,7 @@ platforms.each do |platform|
     end
 
     context 'Create a config file with notification settings' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_global_defs 'global_defs' do
           notification_email_from 'root@mynode'
@@ -53,6 +55,7 @@ platforms.each do |platform|
     end
 
     context 'Create a config with vrrp settings' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_global_defs 'global_defs' do
           router_id 'mynode'
@@ -96,6 +99,7 @@ platforms.each do |platform|
     end
 
     context 'Create a config with snmp settings' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_global_defs 'global_defs' do
           snmp_socket 'unix:/var/agentx/master'
@@ -123,6 +127,7 @@ platforms.each do |platform|
     end
 
     context 'Create a config with custom settings' do
+      cached(:subject) { chef_run }
       recipe do
         global_defs_extra_options = {
           listOfStuff: %w(foo bar),

--- a/spec/resources/http_get_spec.rb
+++ b/spec/resources/http_get_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       name = 'example-80'
       file_name = http_get_file_name(name)
       recipe do
@@ -29,7 +30,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -38,6 +39,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for URL and delay_before_retry' do
+      cached(:subject) { chef_run }
       name = 'flask-3000'
       file_name = http_get_file_name(name)
       url_settings = { path: '/flask', digest: '123', status_code: 201 }
@@ -57,7 +59,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -66,6 +68,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for connect_ip, connect_port and connect_timeout' do
+      cached(:subject) { chef_run }
       name = 'mysql-3306'
       file_name = http_get_file_name(name)
       recipe do
@@ -91,6 +94,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for bind_to, bind_port, warmup and fwmark' do
+      cached(:subject) { chef_run }
       name = 'webserver-443'
       file_name = http_get_file_name(name)
       recipe do

--- a/spec/resources/misc_check_spec.rb
+++ b/spec/resources/misc_check_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       name = 'example-80'
       file_name = misc_check_file_name(name)
       recipe do
@@ -25,7 +26,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -34,6 +35,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for misc_path, misc_timeout warmup and misc_dynamic' do
+      cached(:subject) { chef_run }
       name = 'mysql-3306'
       file_name = misc_check_file_name(name)
       recipe do

--- a/spec/resources/real_server_spec.rb
+++ b/spec/resources/real_server_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       ipaddress = '192.168.1.1'
       port = 80
       file_name = real_server_file_name(ipaddress, port)
@@ -28,7 +29,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -37,6 +38,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for notify_up, notify_down and inhibit_on_failure' do
+      cached(:subject) { chef_run }
       ipaddress = '192.168.1.2'
       port = 443
       file_name = real_server_file_name(ipaddress, port)
@@ -65,6 +67,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for weight and healthcheck' do
+      cached(:subject) { chef_run }
       ipaddress = '192.168.1.3'
       port = 5432
       file_name = real_server_file_name(ipaddress, port)

--- a/spec/resources/smtp_check_spec.rb
+++ b/spec/resources/smtp_check_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       name = 'example-80'
       file_name = smtp_check_file_name(name)
       recipe do
@@ -25,7 +26,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -34,6 +35,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for helo_name and delay_before_rety' do
+      cached(:subject) { chef_run }
       name = 'smtp-25'
       file_name = smtp_check_file_name(name)
       recipe do
@@ -55,6 +57,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for connect_ip, connect_port and connect_timeout' do
+      cached(:subject) { chef_run }
       name = 'mysql-3306'
       file_name = smtp_check_file_name(name)
       recipe do
@@ -80,6 +83,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for bind_to, bind_port, warmup and fwmark' do
+      cached(:subject) { chef_run }
       name = 'webserver-443'
       file_name = smtp_check_file_name(name)
       recipe do

--- a/spec/resources/ssl_get_spec.rb
+++ b/spec/resources/ssl_get_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       name = 'example-80'
       file_name = ssl_get_file_name(name)
       recipe do
@@ -29,7 +30,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -38,6 +39,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for URL and delay_before_retry' do
+      cached(:subject) { chef_run }
       name = 'flask-3000'
       file_name = ssl_get_file_name(name)
       url_settings = { path: '/flask', digest: '123', status_code: 201 }
@@ -57,7 +59,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -66,6 +68,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for connect_ip, connect_port and connect_timeout' do
+      cached(:subject) { chef_run }
       name = 'mysql-3306'
       file_name = ssl_get_file_name(name)
       recipe do
@@ -91,6 +94,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for bind_to, bind_port, warmup and fwmark' do
+      cached(:subject) { chef_run }
       name = 'webserver-443'
       file_name = ssl_get_file_name(name)
       recipe do

--- a/spec/resources/static_ipaddress_spec.rb
+++ b/spec/resources/static_ipaddress_spec.rb
@@ -11,6 +11,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_static_ipaddress 'static_ipaddress' do
           addresses [
@@ -24,7 +25,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(static_ipaddress_config_file).with(
+        is_expected.to create_template(static_ipaddress_config_file).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -33,6 +34,7 @@ platforms.each do |platform|
     end
 
     context 'Create a config file with defined ip addresses' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_static_ipaddress 'static_ipaddress' do
           addresses [

--- a/spec/resources/static_routes_spec.rb
+++ b/spec/resources/static_routes_spec.rb
@@ -11,6 +11,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_static_routes 'static_routes' do
           routes [
@@ -24,7 +25,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(static_routes_config_file).with(
+        is_expected.to create_template(static_routes_config_file).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -33,6 +34,7 @@ platforms.each do |platform|
     end
 
     context 'Create a config file with defined routes' do
+      cached(:subject) { chef_run }
       recipe do
         keepalived_static_routes 'static_routes' do
           routes [

--- a/spec/resources/tcp_check_spec.rb
+++ b/spec/resources/tcp_check_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       name = 'example-80'
       file_name = tcp_check_file_name(name)
       recipe do
@@ -25,7 +26,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -34,6 +35,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for connect_ip, connect_port and connect_timeout' do
+      cached(:subject) { chef_run }
       name = 'mysql-3306'
       file_name = tcp_check_file_name(name)
       recipe do
@@ -59,6 +61,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for bind_to, bind_port, warmup and fwmark' do
+      cached(:subject) { chef_run }
       name = 'webserver-443'
       file_name = tcp_check_file_name(name)
       recipe do

--- a/spec/resources/virtual_server_group_spec.rb
+++ b/spec/resources/virtual_server_group_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       name = 'servers'
       file_name = virtual_server_group_file_name(name)
       recipe do
@@ -25,7 +26,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -34,6 +35,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for vips, and fwmarks' do
+      cached(:subject) { chef_run }
       name = 'webservers'
       vips = ['192.168.1.1 80', '192.168.1.2 80']
       fwmarks = [ 1, 2 ]

--- a/spec/resources/virtual_server_spec.rb
+++ b/spec/resources/virtual_server_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -27,7 +28,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -36,6 +37,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for real_servers, ip_family and delay_loop' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -59,6 +61,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for lvs_sched = rr, ops and lvs_method = NAT' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -86,6 +89,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for lvs_sched = wlc, lvs_method = DR' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -109,6 +113,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for lvs_sched = ovf, ops and lvs_method = DR' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -131,6 +136,7 @@ platforms.each do |platform|
       end
     end
     context 'When given inputs for persistence_engine, persistence_timeout and persistence_granularity' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -158,6 +164,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for protocol, ha_suspend, virtualhost, alpha and omega' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -192,6 +199,7 @@ platforms.each do |platform|
       end
     end
     context 'When given inputs for quorum, hysteresis, quorum_up and quorum_down' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']
@@ -222,6 +230,7 @@ platforms.each do |platform|
       end
     end
     context 'When given inputs for sorry_server and sorry_server_inhibit' do
+      cached(:subject) { chef_run }
       ip_address = '192.168.1.1 80'
       file_name = virtual_server_file_name(ip_address)
       real_servers = ['/etc/keepalived/servers.d/keepalived_real_server__192.168.1.14-443__.conf']

--- a/spec/resources/vrrp_instance_spec.rb
+++ b/spec/resources/vrrp_instance_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       instance_name = 'insideNetwork'
       auth = { auth_type: 'PASS', auth_pass: 'password123!' }
       file_name = vrrp_instance_file_name(instance_name)
@@ -28,7 +29,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -37,6 +38,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for virtual_router_id, master, interface, use_vmac and vmac_xmit_base' do
+      cached(:subject) { chef_run }
       instance_name = 'insideNetwork'
       auth = { auth_type: 'PASS', auth_pass: 'password123!' }
       file_name = vrrp_instance_file_name(instance_name)
@@ -65,6 +67,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for dont_track_primary, track_interface, mcast_src_ip, unicast_src_ip and unicast_peer' do
+      cached(:subject) { chef_run }
       instance_name = 'insideNetwork'
       auth = { auth_type: 'PASS', auth_pass: 'password123!' }
       file_name = vrrp_instance_file_name(instance_name)
@@ -98,6 +101,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for garp_master_delay, garp_master_repeat, garp_master_refresh_repeat, garp_master_refresh_repeat and priority' do
+      cached(:subject) { chef_run }
       instance_name = 'insideNetwork'
       auth = { auth_type: 'PASS', auth_pass: 'password123!' }
       file_name = vrrp_instance_file_name(instance_name)
@@ -131,6 +135,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for advert_int, authentication, virtual_ipaddress, virtual_ipaddress_excluded, virtual_routes and virtual_rules' do
+      cached(:subject) { chef_run }
       instance_name = 'insideNetwork'
       auth = { auth_type: 'PASS', auth_pass: 'secret' }
       file_name = vrrp_instance_file_name(instance_name)
@@ -175,6 +180,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for track_script, nopreempt, preempt_delay, strict_mode, version and native_ipv6' do
+      cached(:subject) { chef_run }
       instance_name = 'insideNetwork'
       auth = { auth_type: 'PASS', auth_pass: 'password123!' }
       file_name = vrrp_instance_file_name(instance_name)
@@ -212,6 +218,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for notify_stop, notify_master, notify_backup, notify_fault, notify and smtp_alert' do
+      cached(:subject) { chef_run }
       instance_name = 'insideNetwork'
       auth = { auth_type: 'PASS', auth_pass: 'password123!' }
       file_name = vrrp_instance_file_name(instance_name)

--- a/spec/resources/vrrp_script_spec.rb
+++ b/spec/resources/vrrp_script_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       script_name = 'foobar'
       file_name = vrrp_script_file_name(script_name)
       recipe do
@@ -26,7 +27,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -35,6 +36,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for interval, weight and script' do
+      cached(:subject) { chef_run }
       script_name = 'chk_haproxy'
       file_name = vrrp_script_file_name(script_name)
       recipe do
@@ -57,6 +59,7 @@ platforms.each do |platform|
     end
 
     context 'When given inputs for timeout, fall, rise and user' do
+      cached(:subject) { chef_run }
       script_name = 'chk_haproxy'
       file_name = vrrp_script_file_name(script_name)
       recipe do

--- a/spec/resources/vrrp_sync_group_spec.rb
+++ b/spec/resources/vrrp_sync_group_spec.rb
@@ -13,6 +13,7 @@ platforms.each do |platform|
     platform platform
 
     context 'Create a base config correctly' do
+      cached(:subject) { chef_run }
       group_name = 'foobar'
       file_name = vrrp_sync_group_file_name(group_name)
       recipe do
@@ -26,7 +27,7 @@ platforms.each do |platform|
       end
 
       it 'creates the config file with the owner, group and mode' do
-        expect(chef_run).to create_template(file_name).with(
+        is_expected.to create_template(file_name).with(
             owner: 'root',
             group: 'root',
             mode: '0640'
@@ -35,6 +36,7 @@ platforms.each do |platform|
     end
 
     context 'Create groups and smtp settings correctly' do
+      cached(:subject) { chef_run }
       group_name = 'foobar'
       file_name = vrrp_sync_group_file_name(group_name)
       recipe do
@@ -54,6 +56,7 @@ platforms.each do |platform|
     end
 
     context 'Create notifies correctly' do
+      cached(:subject) { chef_run }
       group_name = 'foobar'
       file_name = vrrp_sync_group_file_name(group_name)
       recipe do


### PR DESCRIPTION
# Description

- Enables unified_mode for all resources
  - Bumps required Chef version to 15.3+
- Speeds up spec tests by caching the Chef run

## Issues Resolved

(none)

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
