### PR TITLE
fix(vrrp_instances) Do not duplicate the 'notify_master' script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the keepalived cookboo
 
 ## Unreleased
 
+- Fixed a bug that duplicated the `notify_master` script in a `vrrp_instance`
+
 ## 6.0.18 - *2024-05-03*
 
 ## 6.0.17 - *2024-05-03*

--- a/spec/resources/vrrp_instance_spec.rb
+++ b/spec/resources/vrrp_instance_spec.rb
@@ -236,24 +236,36 @@ platforms.each do |platform|
       end
 
       it('should render a config file with the notify_stop correctly') do
-        is_expected.to render_file(file_name).with_content(%r{notify_stop\s/path/to_stop\.sh})
+        is_expected.to render_file(file_name).with_content{|s|
+          expect(s.scan(%r{notify_stop\s/path/to_stop\.sh}).size).to eq(1)
+        }
+
       end
 
       it('should render a config file with the notify_master correctly') do
-        is_expected.to render_file(file_name).with_content(%r{notify_master\s/path/to_master\.sh})
+        is_expected.to render_file(file_name).with_content{|s|
+          expect(s.scan(%r{notify_master\s/path/to_master\.sh}).size).to eq(1)
+        }
       end
 
       it('should render a config file with the notify_backup correctly') do
-        is_expected.to render_file(file_name).with_content(%r{notify_backup\s/path/to_backup\.sh})
+        is_expected.to render_file(file_name).with_content{|s|
+          expect(s.scan(%r{notify_backup\s/path/to_backup\.sh}).size).to eq(1)
+        }
       end
 
       it('should render a config file with the notify_fault correctly') do
-        is_expected.to render_file(file_name).with_content(%r{notify_fault\s/path/fault\.sh})
+        is_expected.to render_file(file_name).with_content{|s|
+          expect(s.scan(%r{notify_fault\s/path/fault\.sh}).size).to eq(1)
+        }
       end
 
       it('should render a config file with the notify correctly') do
-        is_expected.to render_file(file_name).with_content(%r{notify\s/path/notify\.sh})
+        is_expected.to render_file(file_name).with_content{|s|
+          expect(s.scan(%r{notify\s/path/notify\.sh}).size).to eq(1)
+        }
       end
+
       it('should render a config file with the smtp_alert set to true') do
         is_expected.to render_file(file_name).with_content(/smtp_alert\strue/)
       end

--- a/spec/resources/vrrp_instance_spec.rb
+++ b/spec/resources/vrrp_instance_spec.rb
@@ -236,32 +236,31 @@ platforms.each do |platform|
       end
 
       it('should render a config file with the notify_stop correctly') do
-        is_expected.to render_file(file_name).with_content{|s|
+        is_expected.to render_file(file_name).with_content { |s|
           expect(s.scan(%r{notify_stop\s/path/to_stop\.sh}).size).to eq(1)
         }
-
       end
 
       it('should render a config file with the notify_master correctly') do
-        is_expected.to render_file(file_name).with_content{|s|
+        is_expected.to render_file(file_name).with_content { |s|
           expect(s.scan(%r{notify_master\s/path/to_master\.sh}).size).to eq(1)
         }
       end
 
       it('should render a config file with the notify_backup correctly') do
-        is_expected.to render_file(file_name).with_content{|s|
+        is_expected.to render_file(file_name).with_content { |s|
           expect(s.scan(%r{notify_backup\s/path/to_backup\.sh}).size).to eq(1)
         }
       end
 
       it('should render a config file with the notify_fault correctly') do
-        is_expected.to render_file(file_name).with_content{|s|
+        is_expected.to render_file(file_name).with_content { |s|
           expect(s.scan(%r{notify_fault\s/path/fault\.sh}).size).to eq(1)
         }
       end
 
       it('should render a config file with the notify correctly') do
-        is_expected.to render_file(file_name).with_content{|s|
+        is_expected.to render_file(file_name).with_content { |s|
           expect(s.scan(%r{notify\s/path/notify\.sh}).size).to eq(1)
         }
       end

--- a/templates/vrrp_instance.conf.erb
+++ b/templates/vrrp_instance.conf.erb
@@ -124,9 +124,6 @@ vrrp_instance <%= @instance_name %> {
 <% if @notify_master %>
   notify_master <%= @notify_master.to_s %>
 <% end %>
-<% if @notify_master %>
-  notify_master <%= @notify_master.to_s %>
-<% end %>
 <% if @notify_backup %>
   notify_backup <%= @notify_backup.to_s %>
 <% end %>


### PR DESCRIPTION
# Description

Since version v4.0.0 the `notify_master` script was duplicated when rendering a `vrrp_instance`. This PR aims to fix it.

## Issues Resolved

https://github.com/sous-chefs/keepalived/issues/151

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
