### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'keepalived'
+
+run_list 'test::default'
+
+cookbook 'keepalived', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,10 +1,14 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_image: "<%= ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? 'cincproject/cinc' : 'chef/chef' %>"
+  chef_version: "<%= ENV['CHEF_VERSION'] || (ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? 'latest' : 'current') %>"
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  chef_binary: "<%= ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? '/opt/cinc/bin/cinc-client' : '/opt/chef/bin/chef-client' %>"
+  product_name: "<%= ENV['KITCHEN_PRODUCT_NAME'] || 'cinc' %>"
 
 platforms:
   - name: almalinux-8

--- a/resources/virtual_server_group.rb
+++ b/resources/virtual_server_group.rb
@@ -5,7 +5,7 @@ unified_mode true
 
 property :vips,             Array, default: []
 property :fwmarks,          Array, default: [], callbacks: {
-  'are all integers' => ->(spec) { spec.all? { |i| i.is_a?(Integer) } },
+  'are all integers' => ->(spec) { spec.all?(Integer) },
 }
 property :config_directory, String, default: '/etc/keepalived/conf.d'
 # set name to 00_ to force early load-order so it's defined before vrrp_instance(s) which may reference it via track_script

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 # Require all our libraries
 Dir.glob('libraries/*.rb').shuffle.each { |f| require File.expand_path(f) }


### PR DESCRIPTION
## Description

Migrates cookbook dependency management from Berkshelf to Policyfile.

## Changes

- Add `Policyfile.rb`
- Remove `Berksfile`
- Switch ChefSpec setup from `chefspec/berkshelf` to `chefspec/policyfile`
- Update Copilot setup to run `chef install Policyfile.rb`
- Remove stale Berksfile ignore entries

## Verification

- `chef install Policyfile.rb`
- `cookstyle --no-server --cache-root /private/tmp/rubocop_cache`
- `/opt/homebrew/bin/markdownlint-cli2 "**/*.md"`
- `env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec`
- `git diff --check`
- `kitchen list`
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list`
